### PR TITLE
Add ToFrozenMap()

### DIFF
--- a/map.go
+++ b/map.go
@@ -61,13 +61,13 @@ func NewMapFromKeys(keys Set, f func(key interface{}) interface{}) Map {
 	return b.Finish()
 }
 
-// ToFrozenMap takes a map[interface{}]interface{} and returns a frozen Map from it.
-func ToFrozenMap(m map[interface{}]interface{}) Map {
-	keys := NewSetBuilder(len(m))
-	for k, _ := range m {
-		keys.Add(k)
+// NewMapFromGoMap takes a map[interface{}]interface{} and returns a frozen Map from it.
+func NewMapFromGoMap(m map[interface{}]interface{}) Map {
+	mb := NewMapBuilder(len(m))
+	for k, v := range m {
+		mb.Put(k, v)
 	}
-	return NewMapFromKeys(keys.Finish(), func(key interface{}) interface{} { return m[key] })
+	return mb.Finish()
 }
 
 // IsEmpty returns true if the Map has no entries.

--- a/map.go
+++ b/map.go
@@ -61,6 +61,15 @@ func NewMapFromKeys(keys Set, f func(key interface{}) interface{}) Map {
 	return b.Finish()
 }
 
+// ToFrozenMap takes a map[interface{}]interface{} and returns a frozen Map from it.
+func ToFrozenMap(m map[interface{}]interface{}) Map {
+	keys := NewSetBuilder(len(m))
+	for k, _ := range m {
+		keys.Add(k)
+	}
+	return NewMapFromKeys(keys.Finish(), func(key interface{}) interface{} { return m[key] })
+}
+
 // IsEmpty returns true if the Map has no entries.
 func (m Map) IsEmpty() bool {
 	return m.root == nil

--- a/map_test.go
+++ b/map_test.go
@@ -127,17 +127,19 @@ func TestMapRedundantWithWithout(t *testing.T) {
 	}
 }
 
-func TestToFrozenMap(t *testing.T) {
+func TestNewMapFromGoMap(t *testing.T) {
 	t.Parallel()
 
 	N := 1000000
 	m := make(map[interface{}]interface{}, N)
 	for i := 0; i < N; i++ {
-		m[i] = i
+		m[i] = i * i
 	}
 
-	fm := ToFrozenMap(m)
-	expected := NewMapFromKeys(Iota(N), func(k interface{}) interface{} { return k })
+	fm := NewMapFromGoMap(m)
+	expected := NewMapFromKeys(Iota(N), func(k interface{}) interface{} {
+		return k.(int) * k.(int)
+	})
 	assert.True(t, fm.Equal(expected))
 }
 

--- a/map_test.go
+++ b/map_test.go
@@ -127,6 +127,20 @@ func TestMapRedundantWithWithout(t *testing.T) {
 	}
 }
 
+func TestToFrozenMap(t *testing.T) {
+	t.Parallel()
+
+	N := 1000000
+	m := make(map[interface{}]interface{}, N)
+	for i := 0; i < N; i++ {
+		m[i] = i
+	}
+
+	fm := ToFrozenMap(m)
+	expected := NewMapFromKeys(Iota(N), func(k interface{}) interface{} { return k })
+	assert.True(t, fm.Equal(expected))
+}
+
 func TestMapGetElse(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Added a function to convert `map[interface{}]interface{}` to a frozen Map, requested by @dancantos .