### PR TITLE
Faster -race

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,4 +46,4 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Test
-      run: TESTFLAGS='-race -short -cover' make test
+      run: go test -race -short

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,4 +46,4 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Test
-      run: TESTFLAGS='-race -cover' make test
+      run: TESTFLAGS='-race -short -cover' make test

--- a/intset.go
+++ b/intset.go
@@ -21,6 +21,16 @@ const (
 
 type cellBlock [blockCells]cellMask
 
+func (b *cellBlock) isSubsetOf(c cellBlock) bool {
+	for i, x := range b {
+		y := c[i]
+		if x&^y != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 var emptyBlock cellBlock
 
 func locateBlock(i int) (blockIndex, cellIndex int, bitMask cellMask) {
@@ -126,8 +136,9 @@ func (s IntSet) EqualSet(t IntSet) bool {
 
 // IsSubsetOf returns true if s is a subset of t and false otherwise.
 func (s IntSet) IsSubsetOf(t IntSet) bool {
-	for sBlock := s.data.Range(); sBlock.Next(); {
-		if tBlock, exists := t.data.Get(sBlock.Key()); !exists || tBlock != sBlock.Value() {
+	for r := s.data.Range(); r.Next(); {
+		sBlock := r.Value().(cellBlock)
+		if tBlock, has := t.data.Get(r.Key()); !has || !sBlock.isSubsetOf(tBlock.(cellBlock)) {
 			return false
 		}
 	}

--- a/intset_test.go
+++ b/intset_test.go
@@ -55,7 +55,7 @@ func TestIntSetHas(t *testing.T) {
 	for _, i := range arr {
 		assert.True(t, set.Has(i))
 	}
-	assert.False(t, set.Has(arr[len(arr)-1]-1))
+	assert.False(t, set.Has(-1))
 }
 
 func TestIntSetWith(t *testing.T) {
@@ -65,13 +65,17 @@ func TestIntSetWith(t *testing.T) {
 	set := NewIntSet(arr[:len(arr)/2]...)
 
 	for _, i := range arr[len(arr)/2:] {
-		assert.False(t, set.Has(i))
+		if !assert.False(t, set.Has(i), i) {
+			break
+		}
 	}
 
 	set = set.With(arr[len(arr)/2:]...)
 
 	for _, i := range arr[len(arr)/2:] {
-		assert.True(t, set.Has(i))
+		if !assert.True(t, set.Has(i), i) {
+			break
+		}
 	}
 	assert.Equal(t, len(getDistinctInts(arr)), set.Count())
 }
@@ -85,10 +89,14 @@ func TestIntSetWithout(t *testing.T) {
 	expectedCount := len(getDistinctInts(arr)) - len(getDistinctInts(left))
 	assert.Equal(t, expectedCount, set.Count())
 	for _, i := range left {
-		assert.False(t, set.Has(i))
+		if !assert.False(t, set.Has(i), i) {
+			break
+		}
 	}
 	for _, i := range right {
-		assert.True(t, set.Has(i))
+		if !assert.True(t, set.Has(i), i) {
+			break
+		}
 	}
 }
 
@@ -123,18 +131,24 @@ func TestIntSetUnion(t *testing.T) {
 	set := NewIntSet(arr[:len(arr)/2]...)
 	distinct := getDistinctInts(arr)
 	for _, i := range arr[len(arr)/2:] {
-		assert.False(t, set.Has(i))
+		if !assert.False(t, set.Has(i), i) {
+			break
+		}
 	}
 
 	union := set.Union(fullSet)
 	for _, i := range distinct {
-		assert.True(t, union.Has(i))
+		if !assert.True(t, union.Has(i), i) {
+			break
+		}
 	}
 	assert.Equal(t, len(distinct), union.Count())
 
 	union = fullSet.Union(set)
 	for _, i := range distinct {
-		assert.True(t, union.Has(i))
+		if !assert.True(t, union.Has(i), i) {
+			break
+		}
 	}
 	assert.Equal(t, len(distinct), union.Count())
 }
@@ -202,7 +216,16 @@ func generateIntArrayAndSet(maxLen int) ([]int, IntSet) {
 		arr = append(arr, int(curr))
 		curr *= multiplier
 	}
-	return arr, NewIntSet(arr...)
+
+	seen := make(map[int]bool, len(arr))
+	out := arr[:0]
+	for _, e := range arr {
+		if !seen[e] {
+			out = append(out, e)
+			seen[e] = true
+		}
+	}
+	return out, NewIntSet(out...)
 }
 
 func getDistinctInts(x []int) []int {

--- a/intset_test.go
+++ b/intset_test.go
@@ -10,7 +10,12 @@ import (
 	. "github.com/arr-ai/frozen"
 )
 
-const maxIntArrLen = 1_000_000
+func hugeCollectionSize() int {
+	if testing.Short() {
+		return 50_000
+	}
+	return 1_000_000
+}
 
 func TestIntSetEmpty(t *testing.T) {
 	t.Parallel()
@@ -23,7 +28,7 @@ func TestIntSetEmpty(t *testing.T) {
 func TestNewIntSet(t *testing.T) {
 	t.Parallel()
 
-	arr, set := generateIntArrayAndSet(maxIntArrLen)
+	arr, set := generateIntArrayAndSet(hugeCollectionSize())
 	for _, i := range arr {
 		assert.True(t, set.Has(i), i)
 	}
@@ -32,8 +37,8 @@ func TestNewIntSet(t *testing.T) {
 func TestIntSetIter(t *testing.T) {
 	t.Parallel()
 
-	arr, set := generateIntArrayAndSet(maxIntArrLen)
-	container := make([]int, 0, maxIntArrLen)
+	arr, set := generateIntArrayAndSet(hugeCollectionSize())
+	container := make([]int, 0, hugeCollectionSize())
 	for i := set.Range(); i.Next(); {
 		container = append(container, i.Value())
 	}
@@ -46,7 +51,7 @@ func TestIntSetIter(t *testing.T) {
 func TestIntSetHas(t *testing.T) {
 	t.Parallel()
 
-	arr, set := generateIntArrayAndSet(maxIntArrLen)
+	arr, set := generateIntArrayAndSet(hugeCollectionSize())
 	for _, i := range arr {
 		assert.True(t, set.Has(i))
 	}
@@ -56,7 +61,7 @@ func TestIntSetHas(t *testing.T) {
 func TestIntSetWith(t *testing.T) {
 	t.Parallel()
 
-	arr, _ := generateIntArrayAndSet(maxIntArrLen)
+	arr, _ := generateIntArrayAndSet(hugeCollectionSize())
 	set := NewIntSet(arr[:len(arr)/2]...)
 
 	for _, i := range arr[len(arr)/2:] {
@@ -74,7 +79,7 @@ func TestIntSetWith(t *testing.T) {
 func TestIntSetWithout(t *testing.T) {
 	t.Parallel()
 
-	arr, set := generateIntArrayAndSet(maxIntArrLen)
+	arr, set := generateIntArrayAndSet(hugeCollectionSize())
 	left, right := arr[:len(arr)/2], arr[len(arr)/2:]
 	set = set.Without(left...)
 	expectedCount := len(getDistinctInts(arr)) - len(getDistinctInts(left))
@@ -90,7 +95,7 @@ func TestIntSetWithout(t *testing.T) {
 func TestIntSetIntersection(t *testing.T) {
 	t.Parallel()
 
-	arr, fullSet := generateIntArrayAndSet(maxIntArrLen)
+	arr, fullSet := generateIntArrayAndSet(hugeCollectionSize())
 	firstQuartile := NewIntSet(arr[:len(arr)/4]...)
 	secondToFifthDecile := NewIntSet(arr[len(arr)/5 : len(arr)/2]...)
 	thirdQuartile := NewIntSet(arr[len(arr)/2 : 3*len(arr)/4]...)
@@ -114,7 +119,7 @@ func TestIntSetIntersection(t *testing.T) {
 func TestIntSetUnion(t *testing.T) {
 	t.Parallel()
 
-	arr, fullSet := generateIntArrayAndSet(maxIntArrLen)
+	arr, fullSet := generateIntArrayAndSet(hugeCollectionSize())
 	set := NewIntSet(arr[:len(arr)/2]...)
 	distinct := getDistinctInts(arr)
 	for _, i := range arr[len(arr)/2:] {
@@ -137,7 +142,7 @@ func TestIntSetUnion(t *testing.T) {
 func TestIntSetIsSubsetOf(t *testing.T) {
 	t.Parallel()
 
-	arr, fullSet := generateIntArrayAndSet(maxIntArrLen)
+	arr, fullSet := generateIntArrayAndSet(hugeCollectionSize())
 	assert.True(t, NewIntSet().IsSubsetOf(fullSet))
 	assert.True(t, fullSet.IsSubsetOf(fullSet))
 	assert.True(t, NewIntSet(arr[:len(arr)/2]...).IsSubsetOf(fullSet))
@@ -147,7 +152,7 @@ func TestIntSetIsSubsetOf(t *testing.T) {
 func TestIntSetWhere(t *testing.T) {
 	t.Parallel()
 
-	arr, fullSet := generateIntArrayAndSet(maxIntArrLen)
+	arr, fullSet := generateIntArrayAndSet(hugeCollectionSize())
 	var evens, odds []int
 	evenPred := func(e int) bool { return e%2 == 0 }
 	oddPred := func(e int) bool { return e%2 != 0 }
@@ -176,7 +181,7 @@ func TestIntSetMap(t *testing.T) {
 	t.Parallel()
 
 	subtract := func(e int) int { return e - 1 }
-	arr, fullSet := generateIntArrayAndSet(maxIntArrLen)
+	arr, fullSet := generateIntArrayAndSet(hugeCollectionSize())
 	mappedArr := make([]int, 0, len(arr))
 
 	for _, i := range arr {

--- a/lazy/set_test.go
+++ b/lazy/set_test.go
@@ -34,6 +34,10 @@ func (s eagerLazySlice) Swap(i, j int) {
 func TestSet(t *testing.T) { //nolint:funlen,cyclop
 	t.Parallel()
 
+	if testing.Short() {
+		return
+	}
+
 	type work struct {
 		line  int
 		index int

--- a/map_extra_test.go
+++ b/map_extra_test.go
@@ -22,7 +22,6 @@ func TestMapMarshalJSON(t *testing.T) {
 
 	j, err = json.Marshal(NewMap(KV(1, 2), KV(3, 4), KV(4, 2)))
 	if assert.NoError(t, err) {
-		t.Log(string(j))
 		var s [][]int
 		require.NoError(t, json.Unmarshal(j, &s))
 		assert.ElementsMatch(t, [][]int{{1, 2}, {3, 4}, {4, 2}}, s)

--- a/map_test.go
+++ b/map_test.go
@@ -132,7 +132,7 @@ func TestMapRedundantWithWithout(t *testing.T) {
 func TestNewMapFromGoMap(t *testing.T) {
 	t.Parallel()
 
-	N := 1000000
+	N := hugeCollectionSize()
 	m := make(map[interface{}]interface{}, N)
 	for i := 0; i < N; i++ {
 		m[i] = i * i
@@ -374,7 +374,6 @@ func TestMapMergeSameValueType(t *testing.T) {
 	}
 	expected := NewMap(KV(1, 4), KV(2, 7), KV(3, 3), KV(4, 4))
 	result := m.Merge(n, resolve)
-	t.Log(result.String())
 	assert.True(t, expected.Equal(result))
 }
 

--- a/relation_test.go
+++ b/relation_test.go
@@ -91,6 +91,10 @@ func (a bitRelation) join(b bitRelation) bitRelation {
 func TestJoinExhaustive(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() {
+		return
+	}
+
 	outerTotal := 0
 	for i0 := uint64(1); i0 < 0x100; /*1_0000_0000*/ i0++ {
 		i0 := i0

--- a/relation_test.go
+++ b/relation_test.go
@@ -103,7 +103,6 @@ func TestJoinExhaustive(t *testing.T) {
 		})
 		outerTotal++
 	}
-	t.Logf("%d subtests created", outerTotal)
 }
 
 func testJoinExhaustiveCase(t *testing.T, i0 uint64) {

--- a/set_builder_test.go
+++ b/set_builder_test.go
@@ -33,7 +33,10 @@ func TestSetBuilderIncremental(t *testing.T) {
 	t.Parallel()
 
 	replayable(true, func(r replayer) {
-		const N = 1000
+		N := 1_000
+		if testing.Short() {
+			N /= 10
+		}
 		arr := make([]interface{}, 0, N)
 		for i := 0; i < N; i++ {
 			arr = append(arr, i)

--- a/set_test.go
+++ b/set_test.go
@@ -80,7 +80,10 @@ func fromStringArr(a []string) []interface{} {
 func TestNewSet(t *testing.T) {
 	t.Parallel()
 
-	const N = 1_000
+	N := 1_000
+	if testing.Short() {
+		N /= 10
+	}
 	arr := make([]interface{}, 0, N)
 	for i := 0; i < N; i++ {
 		arr = append(arr, i)
@@ -110,7 +113,11 @@ func TestSetWith(t *testing.T) {
 
 	var s Set
 	arr := []interface{}{}
-	for i := 0; i < 1_000; i++ {
+	n := 1_000
+	if testing.Short() {
+		n /= 10
+	}
+	for i := 0; i < n; i++ {
 		assertSetEqual(t, NewSet(arr...), s, "i=%v", i)
 		assert.Equal(t, i, s.Count(), "i=%v", i)
 		assert.False(t, s.Has(i), "i=%v", i)
@@ -126,7 +133,10 @@ func TestSetWithout(t *testing.T) {
 
 	var s Set
 	arr := []interface{}{}
-	const N = 1_000
+	N := 1_000
+	if testing.Short() {
+		N /= 10
+	}
 	for i := 0; i < N; i++ {
 		s = s.With(i)
 		arr = append(arr, i)
@@ -230,6 +240,9 @@ func TestSetEqualLarge(t *testing.T) {
 	t.Parallel()
 
 	n := 100_000
+	if testing.Short() {
+		n /= 10
+	}
 	a := intSet(0, n)
 	b := intSet(0, n)
 	c := intSet(n, n).Map(func(e interface{}) interface{} { return e.(int) - n })
@@ -307,9 +320,13 @@ func TestSetIsSubsetOf(t *testing.T) {
 func TestSetIsSubsetOfLarge(t *testing.T) {
 	t.Parallel()
 
-	a := intSet(0, 100_000)
-	b := intSet(0, 100_001)
-	c := intSet(1, 100_000)
+	n := 100_000
+	if testing.Short() {
+		n /= 10
+	}
+	a := intSet(0, n)
+	b := intSet(0, n+1)
+	c := intSet(1, n)
 	assert.True(t, a.IsSubsetOf(a))
 	assert.True(t, a.IsSubsetOf(b))
 	assert.False(t, b.IsSubsetOf(a))
@@ -374,7 +391,7 @@ func TestSetMapLarge(t *testing.T) {
 	s := hugeIntSet()
 	assertSetEqual(t, NewSet(42), s.Map(func(e interface{}) interface{} { return 42 }))
 	assertSetEqual(t, Iota3(0, 2*s.Count(), 2), s.Map(func(e interface{}) interface{} { return 2 * e.(int) }))
-	assertSetEqual(t, Iota(100_000), s.Map(func(e interface{}) interface{} { return e.(int) / 10 }))
+	assertSetEqual(t, Iota(s.Count()/10), s.Map(func(e interface{}) interface{} { return e.(int) / 10 }))
 }
 
 func TestSetReduce(t *testing.T) {
@@ -408,15 +425,14 @@ func testSetBinaryOperator(t *testing.T, bitop func(a, b uint64) uint64, setop f
 		0x0888: {}, // 000100010001000
 		0x4210: {}, // 100001000010000
 	}
-	for i := 0; i < 100; i++ {
-		m[uint64(i)] = struct{}{}
-	}
-
 	f := 10
 	if testing.Short() {
 		f = 1
 	}
 
+	for i := 0; i < f*10; i++ {
+		m[uint64(i)] = struct{}{}
+	}
 	for i := 100; i < f*1_000; i += 100 {
 		m[uint64(i)] = struct{}{}
 	}
@@ -454,7 +470,11 @@ func TestSetIntersection(t *testing.T) {
 func TestSetIntersectionLarge(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i <= 13; i++ {
+	bits := 13
+	if testing.Short() {
+		bits -= 3
+	}
+	for i := 0; i <= bits; i++ {
 		a := Iota2(1<<uint(i), 9<<uint(i))
 		b := Iota(9 << uint(i)).Intersection(Iota2(1<<uint(i), 10<<uint(i)))
 		if !assertSetEqual(t, a, b, "%d", i) {
@@ -618,9 +638,13 @@ func TestSetUnion_Big(t *testing.T) {
 	s2 := s.Union(s)
 	assertSetEqual(t, s, s2)
 
-	s = intSet(0, 100_000)
-	s2 = intSet(50_000, 100_000)
-	assertSetEqual(t, intSet(0, 150_000), s.Union(s2))
+	n := 100_000
+	if testing.Short() {
+		n /= 10
+	}
+	s = intSet(0, n)
+	s2 = intSet(n/2, n)
+	assertSetEqual(t, intSet(0, n*3/2), s.Union(s2))
 
 	s = hugeIntSet()
 	s2 = s.Union(s)


### PR DESCRIPTION
Tweak tests to reduce the workload under `go test -short -race`.