### PR TITLE
Add audit log with v1.8.0 release entry

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -1,0 +1,9 @@
+# Audit Log
+
+Chronological record of audits, releases, documentation passes, and other
+maintenance activities. Append-only — newest entries at the bottom.
+
+## 2026-02-28 — /release v1.8.0
+
+- **Commit**: `3d0b250`
+- **Outcome**: Released v1.8.0. Added STABILITY.md with full interaction surface catalogue for future breaking-change audits. No breaking changes since v1.7.0 — all changes were internal optimizations (h0 recursive XOR hash, HAMT allocation reduction, CI lint upgrade).


### PR DESCRIPTION
## Summary
- Creates `docs/audit-log.md` with the v1.8.0 release entry
- Follows the standard audit log convention for `/status` skill integration

## Test plan
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)