### PR TITLE
Prepare v1.9.0 release

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -1,0 +1,41 @@
+Third-party code bundled in this repository
+===========================================
+
+1. arr-ai/hash
+   Location : internal/pkg/hash/ (hash.go, hashable.go, h128.go, asm_ppc64x.h)
+   Licence  : Apache License 2.0
+   Source   : https://github.com/arr-ai/hash
+   See      : internal/pkg/hash/LICENSE
+
+2. Go runtime hash functions
+   Location : internal/pkg/hash/ (alg.go, hash32.go, hash64.go, stubs.go,
+              arch_*.go, asm_*.s)
+   Licence  : BSD 3-Clause
+   Source   : https://github.com/golang/go (src/runtime)
+   Copyright: Copyright 2014 The Go Authors. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in
+        the documentation and/or other materials provided with the
+        distribution.
+      * Neither the name of Google Inc. nor the names of its contributors
+        may be used to endorse or promote products derived from this
+        software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -7,7 +7,7 @@ so that each release can be mechanically audited for breakage.
 
 ## Interaction surface catalogue
 
-Snapshot as of v1.8.0.
+Snapshot as of v1.9.0.
 
 ### Package `frozen`
 
@@ -19,9 +19,13 @@ type Iterator[T any] interface {
     Value() T
 }
 
+type Hashable interface {
+    Hash(seed uintptr) uintptr
+}
+
 type Key[T any] interface {
     value.Equaler[T]  // Equal(T) bool
-    hash.Hashable     // Hash(seed uintptr) uintptr
+    Hashable          // Hash(seed uintptr) uintptr
 }
 ```
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -7,3 +7,8 @@ maintenance activities. Append-only — newest entries at the bottom.
 
 - **Commit**: `3d0b250`
 - **Outcome**: Released v1.8.0. Added STABILITY.md with full interaction surface catalogue for future breaking-change audits. No breaking changes since v1.7.0 — all changes were internal optimizations (h0 recursive XOR hash, HAMT allocation reduction, CI lint upgrade).
+
+## 2026-03-02 — /release v1.9.0
+
+- **Commit**: `6bc3bbe`
+- **Outcome**: Released v1.9.0. H128 single-call 128-bit AES hash internalized from arr-ai/hash, eliminating external dependency. Added `frozen.Hashable` interface (additive, non-breaking). NOTICES file added for vendored code attribution. Breaking change audit passed — no removals or signature changes.


### PR DESCRIPTION
## Summary
- Add NOTICES file for vendored hash package attribution (Go runtime BSD + arr-ai/hash Apache 2.0)
- Update STABILITY.md catalogue: add `frozen.Hashable` interface, snapshot v1.9.0
- Add audit log entry for v1.9.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)