### PR TITLE
Prepare v1.10.0 release

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -7,7 +7,7 @@ so that each release can be mechanically audited for breakage.
 
 ## Interaction surface catalogue
 
-Snapshot as of v1.9.0.
+Snapshot as of v1.10.0.
 
 ### Package `frozen`
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -12,3 +12,8 @@ maintenance activities. Append-only — newest entries at the bottom.
 
 - **Commit**: `6bc3bbe`
 - **Outcome**: Released v1.9.0. H128 single-call 128-bit AES hash internalized from arr-ai/hash, eliminating external dependency. Added `frozen.Hashable` interface (additive, non-breaking). NOTICES file added for vendored code attribution. Breaking change audit passed — no removals or signature changes.
+
+## 2026-03-04 — /release v1.10.0
+
+- **Commit**: TBD
+- **Outcome**: Released v1.10.0. EqHash interface refactoring for 19% geomean perf improvement. Restored `reflect.DeepEqual` compatibility broken in v1.8.0 by removing func-valued field from Tree struct. Retracted v1.8.0–v1.9.0. Breaking change audit passed — all changes internal.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,3 +1,4 @@
 # TODO
 
 - [ ] Ensure different types with the same underlying value hash differently (e.g., `int(1)` vs `uint(1)` vs custom `type MyInt int` should not collide)
+- [ ] Add `reflect.DeepEqual` regression tests for `Set` and `Map` — verify that values built via different construction paths (e.g., `NewMap().With(...)` vs `NewMap().Update(m)`) remain `DeepEqual`. This regressed in v1.8.0–v1.9.0 due to an unexported func field in the tree struct.

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,7 @@ module github.com/arr-ai/frozen
 go 1.19
 
 require golang.org/x/sys v0.13.0
+
+// v1.8.0–v1.9.0 broke reflect.DeepEqual for Map/Set due to an unexported
+// func field in the tree struct. Fixed in v1.10.0.
+retract [v1.8.0, v1.9.0]


### PR DESCRIPTION
Retract v1.8.0–v1.9.0 for reflect.DeepEqual breakage. Update STABILITY.md
catalogue to v1.10.0. Add DeepEqual regression test TODO.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
