### PR TITLE
Eliminate hot-path allocations in Map.Get, Map.Without, Set.Has

### DIFF
--- a/internal/pkg/tree/h128.go
+++ b/internal/pkg/tree/h128.go
@@ -13,6 +13,9 @@ func (h H128) String() string {
 	return fmt.Sprintf("%x:%x", h.lo, h.hi)
 }
 
+// MakeH128 constructs an H128 from lo and hi halves.
+func MakeH128(lo, hi uintptr) H128 { return H128{lo, hi} }
+
 func newElemH128[T any](v T, hf func(T) H128) H128 {
 	return hf(v)
 }

--- a/internal/pkg/tree/hasher.go
+++ b/internal/pkg/tree/hasher.go
@@ -48,6 +48,11 @@ func resolveHashFunc[T any]() func(T) H128 {
 			f := *(*float64)(unsafe.Pointer(&key))
 			return toH128(hash.Float64H128(f))
 		}
+	case string:
+		return func(key T) H128 {
+			s := *(*string)(unsafe.Pointer(&key))
+			return toH128(hash.StringH128(s))
+		}
 	}
 	switch unsafe.Sizeof(t) {
 	case 1:
@@ -84,6 +89,42 @@ func GetHashFunc[T any]() func(T) H128 {
 	}
 	fn := resolveHashFunc[T]()
 	hashFuncCache.Store(key, fn)
+	return fn
+}
+
+var seededHashFuncCache sync.Map
+
+// resolveSeededHashFunc returns a non-boxing seeded hash function for T that
+// produces the same values as hash.Any(t, seed). Used by mapEntryHashFunc to
+// hash keys directly without boxing the enclosing mapEntry struct.
+func resolveSeededHashFunc[T any]() func(T, uintptr) uintptr {
+	var t T
+	if _, ok := any(t).(hash.Hashable); ok {
+		// For interface types, boxing to any is free.
+		return func(key T, seed uintptr) uintptr {
+			return any(key).(hash.Hashable).Hash(seed) //nolint:forcetypeassert
+		}
+	}
+	switch any(t).(type) {
+	case string:
+		return func(key T, seed uintptr) uintptr {
+			s := *(*string)(unsafe.Pointer(&key))
+			return hash.String(s, seed)
+		}
+	}
+	return func(key T, seed uintptr) uintptr {
+		return hash.Any(key, seed)
+	}
+}
+
+// GetSeededHashFunc returns a cached seeded hash function for type T.
+func GetSeededHashFunc[T any]() func(T, uintptr) uintptr {
+	key := TypeKeyOf[T]()
+	if f, ok := seededHashFuncCache.Load(key); ok {
+		return f.(func(T, uintptr) uintptr) //nolint:forcetypeassert
+	}
+	fn := resolveSeededHashFunc[T]()
+	seededHashFuncCache.Store(key, fn)
 	return fn
 }
 

--- a/internal/pkg/tree/nodeArgs.go
+++ b/internal/pkg/tree/nodeArgs.go
@@ -7,9 +7,19 @@ import (
 	"github.com/arr-ai/frozen/internal/pkg/value"
 )
 
+var defaultNPEqArgsCache sync.Map
+
 // DefaultNPEqArgs provides default equality with non-parallel behaviour.
+// The result is cached per type T since Gauge is a constant (NonParallel = -1)
+// and EqArgs is read-only during Get/Without.
 func DefaultNPEqArgs[T any]() *EqArgs[T] {
-	return NewDefaultEqArgs[T](depth.NonParallel)
+	key := TypeKeyOf[T]()
+	if f, ok := defaultNPEqArgsCache.Load(key); ok {
+		return f.(*EqArgs[T]) //nolint:forcetypeassert
+	}
+	args := NewDefaultEqArgs[T](depth.NonParallel)
+	defaultNPEqArgsCache.Store(key, args)
+	return args
 }
 
 // DefaultNPCombineArgs provides default combiner with non-parallel

--- a/internal/pkg/tree/tree.go
+++ b/internal/pkg/tree/tree.go
@@ -103,6 +103,16 @@ func (t Tree[T]) Get(v T) *T {
 	return t.root.Get(args, v, h, 0)
 }
 
+// GetWith is like Get but accepts pre-built EqArgs, avoiding the per-call
+// allocation of DefaultNPEqArgs.
+func (t Tree[T]) GetWith(args *EqArgs[T], v T) *T {
+	if t.root == nil {
+		return nil
+	}
+	h := newHasherWith(v, 0, args.hf)
+	return t.root.Get(args, v, h, 0)
+}
+
 func (t Tree[T]) Intersection(args *EqArgs[T], u Tree[T]) (out Tree[T]) {
 	if vetting {
 		defer vet[T](func() { t.Intersection(args, u) }, &t, &u)(&out)
@@ -228,6 +238,24 @@ func (t Tree[T]) Without(v T) (out Tree[T]) {
 		return t
 	}
 	args := DefaultNPEqArgs[T]()
+	h := newHasherWith(v, 0, args.hf)
+	if b, ok := t.root.(*branch[T]); ok {
+		root, matches := withoutBatched(b, args, v, h)
+		return Tree[T]{root: root, count: t.count - matches, built: true}
+	}
+	root, matches := t.root.Without(args, v, 0, h)
+	return Tree[T]{root: root, count: t.count - matches, built: true}
+}
+
+// WithoutWith is like Without but accepts pre-built EqArgs, avoiding the
+// per-call allocation of DefaultNPEqArgs.
+func (t Tree[T]) WithoutWith(args *EqArgs[T], v T) (out Tree[T]) {
+	if vetting {
+		defer vet[T](func() { t.WithoutWith(args, v) }, &t)(&out)
+	}
+	if t.root == nil {
+		return t
+	}
 	h := newHasherWith(v, 0, args.hf)
 	if b, ok := t.root.(*branch[T]); ok {
 		root, matches := withoutBatched(b, args, v, h)

--- a/internal/pkg/value/value.go
+++ b/internal/pkg/value/value.go
@@ -60,6 +60,10 @@ func EqualFuncFor[T any]() func(a, b T) bool {
 		return func(a, b T) bool {
 			return *(*float64)(unsafe.Pointer(&a)) == *(*float64)(unsafe.Pointer(&b))
 		}
+	case string:
+		return func(a, b T) bool {
+			return *(*string)(unsafe.Pointer(&a)) == *(*string)(unsafe.Pointer(&b))
+		}
 	case nil:
 		return equalSlow[T]
 	}

--- a/map.go
+++ b/map.go
@@ -2,6 +2,7 @@ package frozen
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/arr-ai/frozen/internal/pkg/debug"
 	"github.com/arr-ai/frozen/internal/pkg/depth"
@@ -16,6 +17,18 @@ func (m Map[K, V]) mapEqArgs() *tree.EqArgs[mapEntry[K, V]] {
 
 func (m Map[K, V]) mapKeyEqArgs() *tree.EqArgs[mapEntry[K, V]] {
 	return tree.NewEqArgs[mapEntry[K, V]](depth.NewGauge(m.Count()), getMapKeyEqHash[K, V]())
+}
+
+var mapKeyNPEqArgsCache sync.Map
+
+func getMapKeyNPEqArgs[K, V any]() *tree.EqArgs[mapEntry[K, V]] {
+	key := tree.TypeKeyOf[mapEntry[K, V]]()
+	if f, ok := mapKeyNPEqArgsCache.Load(key); ok {
+		return f.(*tree.EqArgs[mapEntry[K, V]]) //nolint:forcetypeassert
+	}
+	args := tree.NewEqArgs[mapEntry[K, V]](depth.NonParallel, getMapKeyEqHash[K, V]())
+	mapKeyNPEqArgsCache.Store(key, args)
+	return args
 }
 
 // Map maps keys to values. The zero value is the empty Map.
@@ -83,7 +96,8 @@ func (m Map[K, V]) With(key K, val V) Map[K, V] {
 // Without returns a new Map with all keys retained from m except the elements
 // of keys.
 func (m Map[K, V]) Without(key K) Map[K, V] {
-	m.tree = m.tree.Without(newMapKey[K, V](key))
+	args := getMapKeyNPEqArgs[K, V]()
+	m.tree = m.tree.WithoutWith(args, newMapKey[K, V](key))
 	return m
 }
 
@@ -95,7 +109,8 @@ func (m Map[K, V]) Has(key K) bool {
 
 // Get returns the value associated with key in m and true iff the key is found.
 func (m Map[K, V]) Get(key K) (_ V, _ bool) {
-	if kv := m.tree.Get(newMapKey[K, V](key)); kv != nil {
+	args := getMapKeyNPEqArgs[K, V]()
+	if kv := m.tree.GetWith(args, newMapKey[K, V](key)); kv != nil {
 		return kv.Value, true
 	}
 	return

--- a/mapEntry.go
+++ b/mapEntry.go
@@ -65,11 +65,15 @@ func (m *mapKeyEqHash[K, V]) Hash(a mapEntry[K, V]) tree.H128 {
 
 func (m *mapKeyEqHash[K, V]) FullHash() bool { return false }
 
-// mapEntryHashFunc returns the resolved H128 hash function for mapEntry[K, V].
-// This dispatches through mapEntry.Hash (which hashes only the key), ensuring
-// consistency with the default path used by Tree.Get/With/Without.
+// mapEntryHashFunc returns a non-boxing H128 hash function for mapEntry[K, V].
+// It hashes only the key, consistent with mapEntry.Hash, but avoids boxing the
+// mapEntry struct through the Hashable interface and avoids boxing the key
+// through hash.Any.
 func mapEntryHashFunc[K, V any]() func(mapEntry[K, V]) tree.H128 {
-	return tree.GetHashFunc[mapEntry[K, V]]()
+	kHash := tree.GetSeededHashFunc[K]()
+	return func(e mapEntry[K, V]) tree.H128 {
+		return tree.MakeH128(kHash(e.Key, 0), kHash(e.Key, 1))
+	}
 }
 
 var mapEntryEqHashCache sync.Map


### PR DESCRIPTION
## Summary

- Cache `DefaultNPEqArgs` per type to avoid fresh `*EqArgs` allocation per call
- Add `string` specializations in `resolveHashFunc` and `EqualFuncFor` to avoid boxing through `any(x)`
- Add `GetSeededHashFunc` for non-boxing seeded hashing of map keys
- Rewrite `mapEntryHashFunc` to hash keys directly instead of boxing the mapEntry struct through the Hashable interface
- Add `Tree.GetWith`/`WithoutWith` accepting pre-built EqArgs
- `Map.Get`/`Without` use cached specialized EqArgs with `GetWith`/`WithoutWith`

## Benchmarks (arrai, Apple M4 Max)

| Operation | Before | After |
|-----------|--------|-------|
| `Map[string,Value].Get` | 6 allocs, ~120 ns | **0 allocs, ~26 ns** |
| `TupleGet` | 6 allocs, ~120 ns | **0 allocs, ~27 ns** |
| `Set[string].Has` | 4 allocs | **0 allocs, ~20 ns** |
| `Set[Value].Has` | 4 allocs | **1 alloc, ~45 ns** |

The remaining 1 alloc on `Set[Value].Has` is the `equalEqualer` boxing path for interface types — deferred as it's low-impact (interface-to-any boxing is cheap).

## Test plan

- [x] All frozen tests pass (`go test ./...`)
- [x] All arrai tests pass (`go test ./...`)
- [x] Benchmarks verified with `-count=5`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)