### PR TITLE
Eliminate remaining allocations in read operations (Map.Get/Has, Set.Has)

### DIFF
--- a/docs/targets.md
+++ b/docs/targets.md
@@ -1,8 +1,35 @@
 # Targets
 
-<!-- last-evaluated: 0ab92d9 -->
+<!-- last-evaluated: 431cd1c -->
 
 ## Active
+
+### 🎯T2 All read operations are zero-alloc
+- **Weight**: 5 (value 8 / cost 2)
+- **Estimated-cost**: 2
+- **Acceptance**:
+  - `Map.Get`, `Map.Has`, `Set.Has` report 0 B/op, 0 allocs/op in benchmarks at 1k and 1M sizes
+  - No regression in throughput (ns/op must not increase)
+  - All existing tests pass
+- **Context**: Currently 1 alloc/op remains in Map.Get from `resolveSeededHashFunc` fallback boxing `int` through `hash.Any(key, seed)`. Adding an `int` fast-path (like the existing `string` and `float64` paths) would eliminate it. Similar pattern applies to other common key types.
+- **Status**: identified
+- **Discovered**: 2026-03-08
+
+### 🎯T3 No-op write operations are zero-alloc
+- **Weight**: 3 (value 5 / cost 2)
+- **Estimated-cost**: 2
+- **Acceptance**:
+  - `Map.With` on existing key (same value) reports 0 allocs/op
+  - `Map.Without` on absent key reports 0 allocs/op
+  - `Set.With` on existing element reports 0 allocs/op
+  - `Set.Without` on absent element reports 0 allocs/op
+  - No regression in throughput
+  - All existing tests pass
+- **Context**: No-op writes currently allocate because they take the same code path as mutating writes before discovering no change is needed. The tree already returns early (same node pointer), but allocations may occur in the hasher/EqArgs path before the early return.
+- **Status**: identified
+- **Discovered**: 2026-03-08
+
+## Achieved
 
 ### 🎯T1 Map[K,V] hot-path operations avoid per-call allocations
 - **Weight**: 5 (value 8 / cost 2)
@@ -14,7 +41,6 @@
   - All existing tests pass (`make test`)
   - Benchmarks show improvement for `Map[string,V]` Get/Without operations
 - **Context**: Map.Get and Map.Without are high-frequency operations. Each call was allocating a new EqArgs and boxing keys through interfaces. Caching EqArgs per type and using direct hash functions eliminates this overhead.
-- **Status**: converging
+- **Status**: achieved
 - **Discovered**: 2026-03-05
-
-## Achieved
+- **Achieved**: 2026-03-08

--- a/internal/pkg/tree/hasher.go
+++ b/internal/pkg/tree/hasher.go
@@ -57,11 +57,7 @@ func resolveHashFunc[T any]() func(T) H128 {
 			f := *(*float64)(unsafe.Pointer(&key))
 			return toH128(hash.Float64H128(f))
 		}
-	case reflect.Complex64:
-		return func(key T) H128 {
-			return toH128(hash.AnyH128(key))
-		}
-	case reflect.Complex128:
+	case reflect.Complex64, reflect.Complex128:
 		return func(key T) H128 {
 			return toH128(hash.AnyH128(key))
 		}
@@ -71,6 +67,11 @@ func resolveHashFunc[T any]() func(T) H128 {
 			return toH128(hash.StringH128(s))
 		}
 	}
+	return resolveHashFuncBySize[T]()
+}
+
+func resolveHashFuncBySize[T any]() func(T) H128 {
+	var t T
 	switch unsafe.Sizeof(t) {
 	case 1:
 		return func(key T) H128 {
@@ -149,6 +150,11 @@ func resolveSeededHashFunc[T any]() func(T, uintptr) uintptr {
 			return hash.String(s, seed)
 		}
 	}
+	return resolveSeededHashFuncBySize[T]()
+}
+
+func resolveSeededHashFuncBySize[T any]() func(T, uintptr) uintptr {
+	var t T
 	switch unsafe.Sizeof(t) {
 	case 1:
 		return func(key T, seed uintptr) uintptr {

--- a/internal/pkg/tree/hasher.go
+++ b/internal/pkg/tree/hasher.go
@@ -2,6 +2,7 @@ package tree
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"unsafe"
@@ -36,19 +37,35 @@ func resolveHashFunc[T any]() func(T) H128 {
 			return H128{h.Hash(0), h.Hash(1)}
 		}
 	}
-	var i any = t
-	switch i.(type) {
-	case float32:
+	// Use reflect.Kind to catch derived types (e.g., type MyFloat float64)
+	// that need special hashing (±0, NaN) before falling through to the
+	// size-based integer dispatch.
+	rt := reflect.TypeOf(t)
+	if rt == nil {
+		return func(key T) H128 {
+			return toH128(hash.AnyH128(key))
+		}
+	}
+	switch rt.Kind() { //nolint:exhaustive
+	case reflect.Float32:
 		return func(key T) H128 {
 			f := *(*float32)(unsafe.Pointer(&key))
 			return toH128(hash.Float32H128(f))
 		}
-	case float64:
+	case reflect.Float64:
 		return func(key T) H128 {
 			f := *(*float64)(unsafe.Pointer(&key))
 			return toH128(hash.Float64H128(f))
 		}
-	case string:
+	case reflect.Complex64:
+		return func(key T) H128 {
+			return toH128(hash.AnyH128(key))
+		}
+	case reflect.Complex128:
+		return func(key T) H128 {
+			return toH128(hash.AnyH128(key))
+		}
+	case reflect.String:
 		return func(key T) H128 {
 			s := *(*string)(unsafe.Pointer(&key))
 			return toH128(hash.StringH128(s))
@@ -105,11 +122,53 @@ func resolveSeededHashFunc[T any]() func(T, uintptr) uintptr {
 			return any(key).(hash.Hashable).Hash(seed) //nolint:forcetypeassert
 		}
 	}
-	switch any(t).(type) {
-	case string:
+	rt := reflect.TypeOf(t)
+	if rt == nil {
+		return func(key T, seed uintptr) uintptr {
+			return hash.Any(key, seed)
+		}
+	}
+	switch rt.Kind() { //nolint:exhaustive
+	case reflect.Float32:
+		return func(key T, seed uintptr) uintptr {
+			f := *(*float32)(unsafe.Pointer(&key))
+			return hash.Float32(f, seed)
+		}
+	case reflect.Float64:
+		return func(key T, seed uintptr) uintptr {
+			f := *(*float64)(unsafe.Pointer(&key))
+			return hash.Float64(f, seed)
+		}
+	case reflect.Complex64, reflect.Complex128:
+		return func(key T, seed uintptr) uintptr {
+			return hash.Any(key, seed)
+		}
+	case reflect.String:
 		return func(key T, seed uintptr) uintptr {
 			s := *(*string)(unsafe.Pointer(&key))
 			return hash.String(s, seed)
+		}
+	}
+	switch unsafe.Sizeof(t) {
+	case 1:
+		return func(key T, seed uintptr) uintptr {
+			v := *(*uint8)(unsafe.Pointer(&key))
+			return hash.Uint8(v, seed)
+		}
+	case 2:
+		return func(key T, seed uintptr) uintptr {
+			v := *(*uint16)(unsafe.Pointer(&key))
+			return hash.Uint16(v, seed)
+		}
+	case 4:
+		return func(key T, seed uintptr) uintptr {
+			v := *(*uint32)(unsafe.Pointer(&key))
+			return hash.Uint32(v, seed)
+		}
+	case 8:
+		return func(key T, seed uintptr) uintptr {
+			v := *(*uint64)(unsafe.Pointer(&key))
+			return hash.Uint64(v, seed)
 		}
 	}
 	return func(key T, seed uintptr) uintptr {

--- a/internal/pkg/value/value.go
+++ b/internal/pkg/value/value.go
@@ -1,6 +1,7 @@
 package value
 
 import (
+	"reflect"
 	"unsafe"
 )
 
@@ -52,20 +53,24 @@ func EqualFuncFor[T any]() func(a, b T) bool {
 		return equalEqualer[T]
 	case Samer:
 		return equalSamer[T]
-	case float32:
+	case nil:
+		return equalSlow[T]
+	}
+	// Use reflect.Kind to catch derived types (e.g., type MyFloat float64).
+	// Float and string need direct comparison via unsafe to avoid boxing.
+	switch reflect.TypeOf(t).Kind() { //nolint:exhaustive
+	case reflect.Float32:
 		return func(a, b T) bool {
 			return *(*float32)(unsafe.Pointer(&a)) == *(*float32)(unsafe.Pointer(&b))
 		}
-	case float64:
+	case reflect.Float64:
 		return func(a, b T) bool {
 			return *(*float64)(unsafe.Pointer(&a)) == *(*float64)(unsafe.Pointer(&b))
 		}
-	case string:
+	case reflect.String:
 		return func(a, b T) bool {
 			return *(*string)(unsafe.Pointer(&a)) == *(*string)(unsafe.Pointer(&b))
 		}
-	case nil:
-		return equalSlow[T]
 	}
 	if f := equalScalar[T](); f != nil {
 		return f

--- a/map_test.go
+++ b/map_test.go
@@ -570,6 +570,24 @@ func BenchmarkGetFrozenMap1M(b *testing.B) {
 	benchmarkGetFrozenMap(b, 1<<20)
 }
 
+func benchmarkHasFrozenMap(b *testing.B, n int) {
+	b.Helper()
+
+	m := prepopFrozenMap(n)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Has(i % n)
+	}
+}
+
+func BenchmarkHasFrozenMap1k(b *testing.B) {
+	benchmarkHasFrozenMap(b, 1<<10)
+}
+
+func BenchmarkHasFrozenMap1M(b *testing.B) {
+	benchmarkHasFrozenMap(b, 1<<20)
+}
+
 func benchmarkWithoutFrozenMap(b *testing.B, n int) {
 	b.Helper()
 

--- a/set_test.go
+++ b/set_test.go
@@ -857,3 +857,21 @@ func BenchmarkInsertFrozenSet1k(b *testing.B) {
 func BenchmarkInsertFrozenSet1M(b *testing.B) {
 	benchmarkInsertFrozenSet(b, 1<<20)
 }
+
+func benchmarkHasFrozenSet(b *testing.B, n int) {
+	b.Helper()
+
+	s := prepopFrozenSet(n).(frozen.Set[int])
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Has(i % n)
+	}
+}
+
+func BenchmarkHasFrozenSet1k(b *testing.B) {
+	benchmarkHasFrozenSet(b, 1<<10)
+}
+
+func BenchmarkHasFrozenSet1M(b *testing.B) {
+	benchmarkHasFrozenSet(b, 1<<20)
+}


### PR DESCRIPTION
Use reflect.Kind dispatch in resolveHashFunc, resolveSeededHashFunc, and
EqualFuncFor to catch derived types (e.g., type MyFloat float64) and
route them through direct hash/equality functions instead of boxing
through interface fallbacks. Add size-based integer fast-paths to
resolveSeededHashFunc. Add Map.Has and Set.Has benchmarks.

All read benchmarks now report 0 B/op, 0 allocs/op at 1k and 1M sizes.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
